### PR TITLE
Slow read fix attempt

### DIFF
--- a/SmartSwitch/CMakeLists.txt
+++ b/SmartSwitch/CMakeLists.txt
@@ -26,6 +26,7 @@ function(compile_and_flash target pico USB_VID)
                         pico_stdlib
                         hardware_adc
                         hardware_pio
+                        hardware_dma
                         tinyusb_device
                         tinyusb_board)
   pico_add_extra_outputs(${target})

--- a/SmartSwitch/SmartSwitch.c
+++ b/SmartSwitch/SmartSwitch.c
@@ -9,6 +9,7 @@
 #include "clock.pio.h"
 #include "hardware/adc.h"
 #include "hardware/clocks.h"
+#include "hardware/dma.h"
 #include "hardware/gpio.h"
 #include "hardware/pio.h"
 #include "hardware/sync.h"
@@ -18,7 +19,6 @@
 #include "pico/types.h"
 #include "string.h"
 #include "tusb.h"
-#include "hardware/dma.h"
 
 // Channel count
 #define nAdc 6  // Number of SmartSwitches
@@ -80,8 +80,10 @@ int dma_channels[6];
 
 #define n_current_transfers 200
 
-static uint32_t __attribute__((aligned(8))) dma_buffer_0[6][n_current_transfers];
-static uint32_t __attribute__((aligned(8))) dma_buffer_1[6][n_current_transfers];
+static uint32_t
+    __attribute__((aligned(8))) dma_buffer_0[6][n_current_transfers];
+static uint32_t
+    __attribute__((aligned(8))) dma_buffer_1[6][n_current_transfers];
 
 volatile bool dma_complete[6] = {false};
 volatile bool using_buffer_a[6] = {true, true, true, true, true, true};
@@ -180,34 +182,36 @@ void __isr dma_handler() {
     dma_channel_acknowledge_irq0(dma_channels[i]);
 
     PIO pio = (i < 3) ? pio0 : pio1;
-    uint sm = (i < 3) ? sm_array[i] : sm_array[i-3];
+    uint sm = (i < 3) ? sm_array[i] : sm_array[i - 3];
 
     // Check FIFO level before starting next transfer
-    if (pio_sm_is_rx_fifo_full(pio, sm) || pio_sm_get_rx_fifo_level(pio, sm) > 3) {
-        slow_read = 1;  // Set the slow read flag
+    if (pio_sm_is_rx_fifo_full(pio, sm) ||
+        pio_sm_get_rx_fifo_level(pio, sm) > 3) {
+      slow_read = 1;  // Set the slow read flag
     }
 
     // Set completion flag
     dma_complete[i] = true;
 
     // Set up next transfer (ping-pong buffer)
-    uint32_t* next_buffer = using_buffer_a[i] ?
-      dma_buffer_1[i] : dma_buffer_0[i];
+    uint32_t* next_buffer =
+        using_buffer_a[i] ? dma_buffer_1[i] : dma_buffer_0[i];
 
-    uintptr_t fifo_addr = (i < 3) ?
-      (uintptr_t)&pio0_hw->rxf[sm_array[i]] :
-      (uintptr_t)&pio1_hw->rxf[sm_array[i-3]];
+    uintptr_t fifo_addr = (i < 3) ? (uintptr_t)&pio0_hw->rxf[sm_array[i]]
+                                  : (uintptr_t)&pio1_hw->rxf[sm_array[i - 3]];
 
     // Configure next transfer
     dma_channel_set_write_addr(dma_channels[i], next_buffer, false);
-    dma_channel_set_trans_count(dma_channels[i], n_current_transfers, true); // Start immediately
+    dma_channel_set_trans_count(dma_channels[i], n_current_transfers,
+                                true);  // Start immediately
 
     // Toggle buffer
     using_buffer_a[i] = !using_buffer_a[i];
   }
 }
 
-void setup_dma_channel(int sm_index, PIO pio, uint sm, uint32_t* buffer_a, uint32_t* buffer_b, int samples) {
+void setup_dma_channel(int sm_index, PIO pio, uint sm, uint32_t* buffer_a,
+                       uint32_t* buffer_b, int samples) {
   // Get a free DMA channel
   dma_channels[sm_index] = dma_claim_unused_channel(true);
 
@@ -224,24 +228,20 @@ void setup_dma_channel(int sm_index, PIO pio, uint sm, uint32_t* buffer_a, uint3
   channel_config_set_transfer_data_size(&c, DMA_SIZE_32);
 
   // Set the read address to the PIO FIFO address
-  uintptr_t fifo_addr = (pio == pio0) ?
-    (uintptr_t)&pio0_hw->rxf[sm] :
-    (uintptr_t)&pio1_hw->rxf[sm];
+  uintptr_t fifo_addr = (pio == pio0) ? (uintptr_t)&pio0_hw->rxf[sm]
+                                      : (uintptr_t)&pio1_hw->rxf[sm];
 
   // Pace transfers based on RX FIFO having data available
-  channel_config_set_dreq(&c, (pio == pio0) ?
-      pio_get_dreq(pio0, sm, false) :
-      pio_get_dreq(pio1, sm, false));
+  channel_config_set_dreq(&c, (pio == pio0) ? pio_get_dreq(pio0, sm, false)
+                                            : pio_get_dreq(pio1, sm, false));
 
   // Set up the initial DMA transfer
-  dma_channel_configure(
-      dma_channels[sm_index],
-      &c,
-      buffer_a,    // Write to first buffer
-      (void*)fifo_addr,  // Read from PIO FIFO
-      samples,     // Transfer count
-      false        // Don't start yet
-      );
+  dma_channel_configure(dma_channels[sm_index], &c,
+                        buffer_a,          // Write to first buffer
+                        (void*)fifo_addr,  // Read from PIO FIFO
+                        samples,           // Transfer count
+                        false              // Don't start yet
+  );
 
   // Enable DMA channel complete interrupt
   dma_channel_set_irq0_enabled(dma_channels[sm_index], true);
@@ -250,8 +250,10 @@ void setup_dma_channel(int sm_index, PIO pio, uint sm, uint32_t* buffer_a, uint3
 void init_dma_system() {
   // Initialize DMA
   for (int i = 0; i < 3; i++) {
-    setup_dma_channel(i, pio_0, sm_array[i], dma_buffer_0[i], dma_buffer_1[i], n_current_transfers);
-    setup_dma_channel(i+3, pio_1, sm_array[i+3], dma_buffer_0[i+3], dma_buffer_1[i+3], n_current_transfers);
+    setup_dma_channel(i, pio_0, sm_array[i], dma_buffer_0[i], dma_buffer_1[i],
+                      n_current_transfers);
+    setup_dma_channel(i + 3, pio_1, sm_array[i + 3], dma_buffer_0[i + 3],
+                      dma_buffer_1[i + 3], n_current_transfers);
   }
 
   // Set up DMA IRQ
@@ -507,7 +509,8 @@ void cdc_task(float channel_current_averaged[6], float channel_voltage[6],
         }
 
         for (int i = 0; i < 6; i++) {
-          ped_subtraction[i] = (float)pre_ped_subtraction[i] / n_current_transfers * adc_to_uA;
+          ped_subtraction[i] =
+              (float)pre_ped_subtraction[i] / n_current_transfers * adc_to_uA;
         }
 
         gpio_put(all_pins.P1_0, 1);  // put pedestal pin high
@@ -545,7 +548,6 @@ float get_single_voltage(
   return voltage;
 }
 
-/*
 void get_all_averaged_currents(
     PIO pio_0, PIO pio_1, uint sm[], float current_array[6],
     uint32_t full_current_array[6][full_current_history_length],
@@ -561,30 +563,36 @@ void get_all_averaged_currents(
     current_array[channel] = 0;
   }
 
-  float latest_current_0;
-  float latest_current_1;
-
-  for (uint32_t i = 0; i < n_current_transfers;
-       i++)  // adds current measurements to current_array
-  {
-    for (uint32_t channel = 0; channel < 3; channel++) {
-      if (pio_sm_is_rx_fifo_full(pio_0, sm[channel]) ||
-          pio_sm_is_rx_fifo_full(pio_0, sm[channel + 3])) {
-        if (i > 10 && *before_trip_allowed == 0) {
-          slow_read = 1;
-        }
+  // Wait for all DMA transfers to complete
+  bool all_complete = false;
+  while (!all_complete) {
+    all_complete = true;
+    for (int i = 0; i < 6; i++) {
+      if (!dma_complete[i]) {
+        all_complete = false;
+        break;
       }
+    }
+    // Add a small timeout to prevent hanging
+    if (!all_complete) {
+      sleep_us(100);
+    }
+  }
 
-      // NOTE: with an average of n_current_transfers, overflow does not occur
-      // However, if this average is increased later on, it may be necessary to
-      // divide earlier/increase to 32 bit integers
-      latest_current_0 = (int16_t)pio_sm_get_blocking(pio_0, sm[channel]);
-      latest_current_1 = (int16_t)pio_sm_get_blocking(pio_1, sm[channel + 3]);
+  // adds current measurements to current_array
+  for (uint32_t i = 0; i < n_current_transfers; i++) {
+    for (uint32_t channel = 0; channel < 3; channel++) {
+      uint32_t* buffer = using_buffer_a[channel] ? dma_buffer_1[channel]
+                                                 : dma_buffer_0[channel];
 
-      current_array[channel] += latest_current_0;
-      current_array[channel + 3] += latest_current_1;
+      // Reset completion flag
+      dma_complete[channel] = false;
 
-      if ((latest_current_0 * adc_to_uA >
+      float latest_current = (int16_t)buffer[i];
+
+      current_array[channel] += latest_current;
+
+      if ((latest_current * adc_to_uA >
            trip_currents[channel] - ped_subtraction[channel]) &&
           ((trip_mask & (1 << channel))) && ((~trip_status & (1 << channel))) &&
           *before_trip_allowed == 0) {
@@ -593,22 +601,10 @@ void get_all_averaged_currents(
         num_trigger[channel] -= 1;
       }
 
-      if ((latest_current_1 * adc_to_uA >
-           trip_currents[channel + 3] - ped_subtraction[channel]) &&
-          ((trip_mask & (1 << channel + 3))) &&
-          ((~trip_status & (1 << channel + 3))) && *before_trip_allowed == 0) {
-        num_trigger[channel + 3] += 1;
-      } else if (num_trigger[channel + 3] > 0) {
-        num_trigger[channel + 3] -= 1;
-      }
-
       if (*remaining_buffer_iterations > 0) {
         // update latest full current, along with its position in rotating
         // buffer
-        full_current_array[channel][*full_position] =
-            (uint32_t)latest_current_0;
-        full_current_array[channel + 3][*full_position] =
-            (uint32_t)latest_current_1;
+        full_current_array[channel][*full_position] = (uint32_t)latest_current;
       }
     }
 
@@ -680,151 +676,14 @@ void get_all_averaged_currents(
     // ped_on == 1
     if (ped_on == 1) {
       current_array[channel] =
-          current_array[channel] * adc_to_uA / n_current_transfers - ped_subtraction[channel];
+          current_array[channel] * adc_to_uA / n_current_transfers -
+          ped_subtraction[channel];
     } else {
-      current_array[channel] = current_array[channel] * adc_to_uA / n_current_transfers;
-    }
-  }
-}
-*/
-
-void get_all_averaged_currents(
-    PIO pio_0, PIO pio_1, uint sm[], float current_array[6],
-    uint32_t full_current_array[6][full_current_history_length],
-    uint16_t* full_position, uint8_t* current_buffer_run,
-    int* remaining_buffer_iterations, int* before_trip_allowed) {
-
-  if (*before_trip_allowed > 0) {
-    *before_trip_allowed -= 1;
-  }
-
-  // Initialize current array
-  for (uint32_t channel = 0; channel < 6; channel++) {
-    current_array[channel] = 0;
-  }
-
-  // Wait for all DMA transfers to complete
-  bool all_complete = false;
-  while (!all_complete) {
-    all_complete = true;
-    for (int i = 0; i < 6; i++) {
-      if (!dma_complete[i]) {
-        all_complete = false;
-        break;
-      }
-    }
-    // Add a small timeout to prevent hanging
-    if (!all_complete) {
-      sleep_us(100);
-    }
-  }
-
-  // Process the completed buffers
-  for (uint32_t channel = 0; channel < 6; channel++) {
-    // Get the buffer that was just filled
-    uint32_t* buffer = using_buffer_a[channel] ?
-      dma_buffer_1[channel] : dma_buffer_0[channel];
-
-    // Reset completion flag
-    dma_complete[channel] = false;
-
-    // Process the data -- sum, increment trip count
-    for (int i = 0; i < n_current_transfers; i++) {
-      int16_t current_value = (int16_t)buffer[i];
-      current_array[channel] += current_value;
-
-      // Trip logic
-      if ((current_value * adc_to_uA >
-            trip_currents[channel] - ped_subtraction[channel]) &&
-          ((trip_mask & (1 << channel))) &&
-          ((~trip_status & (1 << channel))) &&
-          *before_trip_allowed == 0) {
-        num_trigger[channel] += 1;
-      } else if (num_trigger[channel] > 0) {
-        num_trigger[channel] -= 1;
-      }
-
-      // Buffer for trip analysis
-      if (*remaining_buffer_iterations > 0 && i % 4 == 0) { // Only store every 4th sample
-        full_current_array[channel][*full_position] = (uint32_t)current_value;
-
-        if (channel == 5) { // Only increment position once per set of channels
-          *full_position += 1;
-          if (*full_position >= full_current_history_length) {
-            *full_position = 0;
-          }
-
-          if (*current_buffer_run == 0 && *remaining_buffer_iterations > 0) {
-            *remaining_buffer_iterations -= 1;
-          }
-        }
-      }
-    }
-  }
-
-  // Trip detection logic
-  int trip_required = 0;
-  for (int channel = 0; channel < 6; channel++) {
-    if (num_trigger[channel] >= trip_requirement[channel]) {
-      trip_required = 1;
-
-      // Set all num_triggers to zero
-      for (int i = 0; i < 6; i++) {
-        num_trigger[i] = 0;
-      }
-
-      break;
-    }
-  }
-
-  // handle trip
-  if (trip_required == 1) {
-    if (*current_buffer_run == 1) {
-      *remaining_buffer_iterations = floor(full_current_history_length / 2);
-      *current_buffer_run = 0;
-    }
-
-    float current_sums[6] = {0, 0, 0, 0, 0, 0};
-    int read_index;
-    for (int channel_index = 0; channel_index < 6; channel_index++) {
-      for (int current_index = 0; current_index < 25; current_index++) {
-        if (*full_position - current_index < 0) {
-          read_index = full_current_history_length - current_index;
-        } else {
-          read_index = *full_position - current_index;
-        }
-        current_sums[channel_index] +=
-            full_current_array[channel_index][read_index] * adc_to_uA -
-            trip_currents[channel_index];
-      }
-    }
-
-    int max_channel;
-    float max_value = 0;
-    for (int i = 0; i < 6; i++) {
-      if (current_sums[i] > max_value && ((~trip_status & (1 << i)))) {
-        max_value = current_sums[i];
-        max_channel = i;
-      }
-    }
-
-    gpio_put(all_pins.crowbarPins[max_channel], 1);
-    *before_trip_allowed = 20;
-    trip_status = trip_status | (1 << max_channel);
-  }
-
-  // Scale current values
-  for (uint32_t channel = 0; channel < 6; channel++) {
-    // ped_on == 1
-    if (ped_on == 1) {
       current_array[channel] =
-        current_array[channel] * adc_to_uA / n_current_transfers - ped_subtraction[channel];
-    } else {
-      current_array[channel] = current_array[channel] * adc_to_uA / n_current_transfers;
+          current_array[channel] * adc_to_uA / n_current_transfers;
     }
   }
 }
-
 
 //******************************************************************************
 // Standard loop function, called repeatedly
@@ -909,7 +768,7 @@ int main() {
   // create array of state machines
   // this is used to acquire data from DAQ state machines in other areas of this
   // code
-  //uint sm_array[6];
+  // uint sm_array[6];
   sm_array[0] = sm_channel_0;
   sm_array[1] = sm_channel_1;
   sm_array[2] = sm_channel_2;
@@ -956,8 +815,8 @@ int main() {
             pio_0, pio_1, sm_array, channel_current_averaged,
             full_current_array, &full_position, &current_buffer_run,
             &remaining_buffer_iterations,
-            &before_trip_allowed);  // get average of n_current_transfers full speed current
-                                    // measurements
+            &before_trip_allowed);  // get average of n_current_transfers full
+                                    // speed current measurements
 
         // store averaged currents
         if (average_store_position <

--- a/SmartSwitch/SmartSwitch.c
+++ b/SmartSwitch/SmartSwitch.c
@@ -18,6 +18,7 @@
 #include "pico/types.h"
 #include "string.h"
 #include "tusb.h"
+#include "hardware/dma.h"
 
 // Channel count
 #define nAdc 6  // Number of SmartSwitches
@@ -73,6 +74,19 @@ uint32_t full_current_array[6][full_current_history_length];
 float ped_subtraction[6] = {0, 0, 0, 0, 0, 0};
 float ped_subtraction_stored[6] = {0, 0, 0, 0, 0, 0};
 int ped_on = 1;
+
+// DMA stuff
+int dma_channels[6];
+
+#define n_current_transfers 200
+
+static uint32_t __attribute__((aligned(8))) dma_buffer_0[6][n_current_transfers];
+static uint32_t __attribute__((aligned(8))) dma_buffer_1[6][n_current_transfers];
+
+volatile bool dma_complete[6] = {false};
+volatile bool using_buffer_a[6] = {true, true, true, true, true, true};
+
+uint sm_array[6];
 
 void port_init() {
   uint8_t port;
@@ -153,6 +167,100 @@ void variable_init() {
     all_pins.sclk_1 = 19;    // SPI clock
     all_pins.csPin_1 = 18;   // SPI Chip select for I
     all_pins.enablePin = 8;  // enable pin for MUX
+  }
+}
+
+// DMA interrupt handler
+void __isr dma_handler() {
+  for (int i = 0; i < 6; i++) {
+    if (!dma_channel_get_irq0_status(dma_channels[i])) {
+      continue;
+    }
+
+    dma_channel_acknowledge_irq0(dma_channels[i]);
+
+    PIO pio = (i < 3) ? pio0 : pio1;
+    uint sm = (i < 3) ? sm_array[i] : sm_array[i-3];
+
+    // Check FIFO level before starting next transfer
+    if (pio_sm_is_rx_fifo_full(pio, sm) || pio_sm_get_rx_fifo_level(pio, sm) > 3) {
+        slow_read = 1;  // Set the slow read flag
+    }
+
+    // Set completion flag
+    dma_complete[i] = true;
+
+    // Set up next transfer (ping-pong buffer)
+    uint32_t* next_buffer = using_buffer_a[i] ?
+      dma_buffer_1[i] : dma_buffer_0[i];
+
+    uintptr_t fifo_addr = (i < 3) ?
+      (uintptr_t)&pio0_hw->rxf[sm_array[i]] :
+      (uintptr_t)&pio1_hw->rxf[sm_array[i-3]];
+
+    // Configure next transfer
+    dma_channel_set_write_addr(dma_channels[i], next_buffer, false);
+    dma_channel_set_trans_count(dma_channels[i], n_current_transfers, true); // Start immediately
+
+    // Toggle buffer
+    using_buffer_a[i] = !using_buffer_a[i];
+  }
+}
+
+void setup_dma_channel(int sm_index, PIO pio, uint sm, uint32_t* buffer_a, uint32_t* buffer_b, int samples) {
+  // Get a free DMA channel
+  dma_channels[sm_index] = dma_claim_unused_channel(true);
+
+  // Configure the channel
+  dma_channel_config c = dma_channel_get_default_config(dma_channels[sm_index]);
+
+  // Reading from fixed address (PIO FIFO)
+  channel_config_set_read_increment(&c, false);
+
+  // Writing to incrementing addresses (buffer)
+  channel_config_set_write_increment(&c, true);
+
+  // Transfer 32 bits at a time
+  channel_config_set_transfer_data_size(&c, DMA_SIZE_32);
+
+  // Set the read address to the PIO FIFO address
+  uintptr_t fifo_addr = (pio == pio0) ?
+    (uintptr_t)&pio0_hw->rxf[sm] :
+    (uintptr_t)&pio1_hw->rxf[sm];
+
+  // Pace transfers based on RX FIFO having data available
+  channel_config_set_dreq(&c, (pio == pio0) ?
+      pio_get_dreq(pio0, sm, false) :
+      pio_get_dreq(pio1, sm, false));
+
+  // Set up the initial DMA transfer
+  dma_channel_configure(
+      dma_channels[sm_index],
+      &c,
+      buffer_a,    // Write to first buffer
+      (void*)fifo_addr,  // Read from PIO FIFO
+      samples,     // Transfer count
+      false        // Don't start yet
+      );
+
+  // Enable DMA channel complete interrupt
+  dma_channel_set_irq0_enabled(dma_channels[sm_index], true);
+}
+
+void init_dma_system() {
+  // Initialize DMA
+  for (int i = 0; i < 3; i++) {
+    setup_dma_channel(i, pio_0, sm_array[i], dma_buffer_0[i], dma_buffer_1[i], n_current_transfers);
+    setup_dma_channel(i+3, pio_1, sm_array[i+3], dma_buffer_0[i+3], dma_buffer_1[i+3], n_current_transfers);
+  }
+
+  // Set up DMA IRQ
+  irq_set_exclusive_handler(DMA_IRQ_0, dma_handler);
+  irq_set_enabled(DMA_IRQ_0, true);
+
+  // Start all DMA channels
+  for (int i = 0; i < 6; i++) {
+    dma_channel_start(dma_channels[i]);
   }
 }
 
@@ -389,7 +497,7 @@ void cdc_task(float channel_current_averaged[6], float channel_voltage[6],
 
         int32_t pre_ped_subtraction[6] = {0, 0, 0, 0, 0, 0};
 
-        for (int ped_count = 0; ped_count < 200; ped_count++) {
+        for (int ped_count = 0; ped_count < n_current_transfers; ped_count++) {
           for (int i = 0; i < 3; i++) {
             pre_ped_subtraction[i] +=
                 (int16_t)pio_sm_get_blocking(pio_0, sm_array[i]);
@@ -399,7 +507,7 @@ void cdc_task(float channel_current_averaged[6], float channel_voltage[6],
         }
 
         for (int i = 0; i < 6; i++) {
-          ped_subtraction[i] = (float)pre_ped_subtraction[i] / 200 * adc_to_uA;
+          ped_subtraction[i] = (float)pre_ped_subtraction[i] / n_current_transfers * adc_to_uA;
         }
 
         gpio_put(all_pins.P1_0, 1);  // put pedestal pin high
@@ -437,6 +545,7 @@ float get_single_voltage(
   return voltage;
 }
 
+/*
 void get_all_averaged_currents(
     PIO pio_0, PIO pio_1, uint sm[], float current_array[6],
     uint32_t full_current_array[6][full_current_history_length],
@@ -455,7 +564,7 @@ void get_all_averaged_currents(
   float latest_current_0;
   float latest_current_1;
 
-  for (uint32_t i = 0; i < 200;
+  for (uint32_t i = 0; i < n_current_transfers;
        i++)  // adds current measurements to current_array
   {
     for (uint32_t channel = 0; channel < 3; channel++) {
@@ -466,7 +575,7 @@ void get_all_averaged_currents(
         }
       }
 
-      // NOTE: with an average of 200, overflow does not occur
+      // NOTE: with an average of n_current_transfers, overflow does not occur
       // However, if this average is increased later on, it may be necessary to
       // divide earlier/increase to 32 bit integers
       latest_current_0 = (int16_t)pio_sm_get_blocking(pio_0, sm[channel]);
@@ -571,12 +680,151 @@ void get_all_averaged_currents(
     // ped_on == 1
     if (ped_on == 1) {
       current_array[channel] =
-          current_array[channel] * adc_to_uA / 200 - ped_subtraction[channel];
+          current_array[channel] * adc_to_uA / n_current_transfers - ped_subtraction[channel];
     } else {
-      current_array[channel] = current_array[channel] * adc_to_uA / 200;
+      current_array[channel] = current_array[channel] * adc_to_uA / n_current_transfers;
     }
   }
 }
+*/
+
+void get_all_averaged_currents(
+    PIO pio_0, PIO pio_1, uint sm[], float current_array[6],
+    uint32_t full_current_array[6][full_current_history_length],
+    uint16_t* full_position, uint8_t* current_buffer_run,
+    int* remaining_buffer_iterations, int* before_trip_allowed) {
+
+  if (*before_trip_allowed > 0) {
+    *before_trip_allowed -= 1;
+  }
+
+  // Initialize current array
+  for (uint32_t channel = 0; channel < 6; channel++) {
+    current_array[channel] = 0;
+  }
+
+  // Wait for all DMA transfers to complete
+  bool all_complete = false;
+  while (!all_complete) {
+    all_complete = true;
+    for (int i = 0; i < 6; i++) {
+      if (!dma_complete[i]) {
+        all_complete = false;
+        break;
+      }
+    }
+    // Add a small timeout to prevent hanging
+    if (!all_complete) {
+      sleep_us(100);
+    }
+  }
+
+  // Process the completed buffers
+  for (uint32_t channel = 0; channel < 6; channel++) {
+    // Get the buffer that was just filled
+    uint32_t* buffer = using_buffer_a[channel] ?
+      dma_buffer_1[channel] : dma_buffer_0[channel];
+
+    // Reset completion flag
+    dma_complete[channel] = false;
+
+    // Process the data -- sum, increment trip count
+    for (int i = 0; i < n_current_transfers; i++) {
+      int16_t current_value = (int16_t)buffer[i];
+      current_array[channel] += current_value;
+
+      // Trip logic
+      if ((current_value * adc_to_uA >
+            trip_currents[channel] - ped_subtraction[channel]) &&
+          ((trip_mask & (1 << channel))) &&
+          ((~trip_status & (1 << channel))) &&
+          *before_trip_allowed == 0) {
+        num_trigger[channel] += 1;
+      } else if (num_trigger[channel] > 0) {
+        num_trigger[channel] -= 1;
+      }
+
+      // Buffer for trip analysis
+      if (*remaining_buffer_iterations > 0 && i % 4 == 0) { // Only store every 4th sample
+        full_current_array[channel][*full_position] = (uint32_t)current_value;
+
+        if (channel == 5) { // Only increment position once per set of channels
+          *full_position += 1;
+          if (*full_position >= full_current_history_length) {
+            *full_position = 0;
+          }
+
+          if (*current_buffer_run == 0 && *remaining_buffer_iterations > 0) {
+            *remaining_buffer_iterations -= 1;
+          }
+        }
+      }
+    }
+  }
+
+  // Trip detection logic
+  int trip_required = 0;
+  for (int channel = 0; channel < 6; channel++) {
+    if (num_trigger[channel] >= trip_requirement[channel]) {
+      trip_required = 1;
+
+      // Set all num_triggers to zero
+      for (int i = 0; i < 6; i++) {
+        num_trigger[i] = 0;
+      }
+
+      break;
+    }
+  }
+
+  // handle trip
+  if (trip_required == 1) {
+    if (*current_buffer_run == 1) {
+      *remaining_buffer_iterations = floor(full_current_history_length / 2);
+      *current_buffer_run = 0;
+    }
+
+    float current_sums[6] = {0, 0, 0, 0, 0, 0};
+    int read_index;
+    for (int channel_index = 0; channel_index < 6; channel_index++) {
+      for (int current_index = 0; current_index < 25; current_index++) {
+        if (*full_position - current_index < 0) {
+          read_index = full_current_history_length - current_index;
+        } else {
+          read_index = *full_position - current_index;
+        }
+        current_sums[channel_index] +=
+            full_current_array[channel_index][read_index] * adc_to_uA -
+            trip_currents[channel_index];
+      }
+    }
+
+    int max_channel;
+    float max_value = 0;
+    for (int i = 0; i < 6; i++) {
+      if (current_sums[i] > max_value && ((~trip_status & (1 << i)))) {
+        max_value = current_sums[i];
+        max_channel = i;
+      }
+    }
+
+    gpio_put(all_pins.crowbarPins[max_channel], 1);
+    *before_trip_allowed = 20;
+    trip_status = trip_status | (1 << max_channel);
+  }
+
+  // Scale current values
+  for (uint32_t channel = 0; channel < 6; channel++) {
+    // ped_on == 1
+    if (ped_on == 1) {
+      current_array[channel] =
+        current_array[channel] * adc_to_uA / n_current_transfers - ped_subtraction[channel];
+    } else {
+      current_array[channel] = current_array[channel] * adc_to_uA / n_current_transfers;
+    }
+  }
+}
+
 
 //******************************************************************************
 // Standard loop function, called repeatedly
@@ -661,7 +909,7 @@ int main() {
   // create array of state machines
   // this is used to acquire data from DAQ state machines in other areas of this
   // code
-  uint sm_array[6];
+  //uint sm_array[6];
   sm_array[0] = sm_channel_0;
   sm_array[1] = sm_channel_1;
   sm_array[2] = sm_channel_2;
@@ -685,6 +933,8 @@ int main() {
 
   tud_init(BOARD_TUD_RHPORT);  // tinyUSB formality
 
+  init_dma_system();
+
   while (true)  // DAQ & USB communication Loop, runs forever
   {
     // ----- Collect averaged current measurements ----- //
@@ -706,7 +956,7 @@ int main() {
             pio_0, pio_1, sm_array, channel_current_averaged,
             full_current_array, &full_position, &current_buffer_run,
             &remaining_buffer_iterations,
-            &before_trip_allowed);  // get average of 200 full speed current
+            &before_trip_allowed);  // get average of n_current_transfers full speed current
                                     // measurements
 
         // store averaged currents


### PR DESCRIPTION
Change the method of draining the pio sm fifos in an attempt to fix the slow_read, which always triggered AFAICT.

Simply replace the method of draining the pio sm fifos from `pio_sm_fifo_get` with DMA. DMA is theoretically much faster, channels run in parallel, and is separate from the CPU.

Attempted to keep the rest of `get_all_averaged_currents` unchanged -- no other improvements to that function attempted here.

Working well right now, but performance testing may be desired.